### PR TITLE
Meta: use CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+* @domenic
+views/agreement.hbs @whatwg/sg


### PR DESCRIPTION
This makes https://github.com/whatwg/sg/issues/13 a little less concerning.