### PR TITLE
Change the logo to link to whatwg.org

### DIFF
--- a/layouts/whatwg.hbs
+++ b/layouts/whatwg.hbs
@@ -13,7 +13,7 @@
 <header>
  <hgroup>
   <h1>
-   <a href="/">
+   <a href="https://whatwg.org/">
     <img id="main-logo" src="https://resources.whatwg.org/logo.svg" alt="">
     WHATWG
    </a>


### PR DESCRIPTION
This mainly serves as a test that #18 was fixed; if merging this performs a successful restart, then we can say that https://github.com/whatwg/misc-server/pull/88 (perhaps in combination with #24) was the correct fix.