### PR TITLE
Update some agreement field labels

### DIFF
--- a/views/agreement.hbs
+++ b/views/agreement.hbs
@@ -238,10 +238,10 @@ input[type="submit"] {
     <label for="individual-address">City + Country:</label>
     <input type="text" name="individual-address" id="individual-address" required>
 
-    <label for="individual-email">Contact (email):</label>
+    <label for="individual-email">Email:</label>
     <input type="email" name="individual-email" id="individual-email" required>
 
-    <label for="individual-github">GitHub ID:</label>
+    <label for="individual-github">GitHub Username:</label>
     <input type="text" name="individual-github" id="individual-github" required>
 
     <label for="individual-signature">Signature:</label>
@@ -292,7 +292,7 @@ input[type="submit"] {
      <label for="contact-1-email">Email:</label>
      <input type="email" name="contact-1-email" id="contact-1-email" required>
 
-     <label for="contact-1-github">GitHub ID:</label>
+     <label for="contact-1-github">GitHub Username:</label>
      <input type="text" name="contact-1-github" id="contact-1-github" required>
     </div>
    </fieldset>
@@ -306,7 +306,7 @@ input[type="submit"] {
      <label for="contact-2-email">Email:</label>
      <input type="email" name="contact-2-email" id="contact-2-email">
 
-     <label for="contact-2-github">GitHub ID:</label>
+     <label for="contact-2-github">GitHub Username:</label>
      <input type="text" name="contact-2-github" id="contact-2-github">
     </div>
    </fieldset>


### PR DESCRIPTION
In https://github.com/whatwg/participant-data/pull/7, a participant got confused between GitHub "ID" and GitHub "username". We should say username, as that's what GitHub appears to use in most of their UI. The data model still uses "ID", as changing that would be complicated for little benefit.

Also changes the confusing field label "Contact (email)" for individuals to just "Email" as is done for entity contacts.