### PR TITLE
Update escape-goat from 1.3.0 to 2.1.0

### DIFF
--- a/lib/get-user-status.js
+++ b/lib/get-user-status.js
@@ -4,7 +4,7 @@ const listify = require("listify");
 const config = require("../config.json");
 const gitHubAPI = require("./helpers/github.js").api;
 const jsonGitHubDatabase = require("./helpers/json-github-database.js");
-const html = require("escape-goat").escapeTag;
+const html = require("escape-goat").htmlEscapeTag;
 
 const statusURLBase = (new URL(config.statusPath, config.serverURL)).href;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1752,9 +1752,9 @@
       }
     },
     "escape-goat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-1.3.0.tgz",
-      "integrity": "sha512-E2nU1Y39N5UgfLU8qwMlK0vZrZprIwWLeVmDYN8wd/e37hMtGzu2w1DBiREts0XHfgyZEQlj/hYr0H0izF0HDQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.0.tgz",
+      "integrity": "sha512-7fMXQmS/6yjYQT/yydWKCAm5ucuU7QtqP6/CE7BIKk6z3xTP4MLqkdUBwaViQVuTAde8yZgZIjSnEAPRl6u53g=="
     },
     "escape-html": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^16.28.9",
-    "escape-goat": "^1.3.0",
+    "escape-goat": "^2.1.0",
     "github-username-regex": "^1.0.0",
     "handlebars": "^4.2.0",
     "http-errors": "^1.7.3",


### PR DESCRIPTION
Closes #49 by including the appropriate code updates as well as the dependency bump.