### PR TITLE
Remove leftover TODO styles

### DIFF
--- a/views/agreement.hbs
+++ b/views/agreement.hbs
@@ -57,18 +57,6 @@ legend + p {
  margin-top: 0;
 }
 
-a[href="TODO"] {
- border-bottom: 1px solid red;
- text-decoration: none;
-}
-
-@supports (text-decoration-color: #eee) {
- a[href="TODO"] {
-  text-decoration: underline;
-  text-decoration-color: red;
- }
-}
-
 .disabled-control {
  color: gray;
  cursor: default;


### PR DESCRIPTION
During development these were used to spot broken links. They have not been applicable at any time while this application was live.