### PR TITLE
Fix botched Octokit upgrade

### DIFF
--- a/lib/helpers/github.js
+++ b/lib/helpers/github.js
@@ -1,9 +1,9 @@
 "use strict";
-const GitHub = require("@octokit/rest");
+const { Octokit } = require("@octokit/rest");
 const config = require("../../config.json");
 const privateConfig = require("../../private-config.json");
 
-exports.api = new GitHub({
+exports.api = new Octokit({
   auth: privateConfig.gitHub.accessToken
 });
 


### PR DESCRIPTION
20b1121c8efb31b082422dfdf5ae069438fe2284 upgraded @octokit/rest, but missed a change to the public API that would cause the server to fail to start. This corrects that error.

#79 will prevent this from happening, and after happening twice in a row, I'm upping the priority of that one.