### PR TITLE
More updates for Octokit breaking changes

### DIFF
--- a/__tests__/pr-webhook.js
+++ b/__tests__/pr-webhook.js
@@ -22,7 +22,7 @@ jest.mock("../lib/helpers/github.js", () => {
           return mockCreateStatus;
         }
       },
-      pullRequests: {
+      pulls: {
         get get() {
           return mockPRGet;
         }

--- a/__tests__/update-pr.js
+++ b/__tests__/update-pr.js
@@ -17,7 +17,7 @@ let mockGet;
 jest.mock("../lib/helpers/github.js", () => {
   return {
     api: {
-      pullRequests: {
+      pulls: {
         get get() {
           return mockGet;
         }
@@ -44,7 +44,7 @@ test("A PR from a branch must trigger an appropriate status update", async () =>
   await updatePR("https://github.com/whatwg/console/pull/5");
 
   expect(mockGet).toHaveBeenCalledTimes(1);
-  expect(mockGet.mock.calls[0]).toEqual([{ owner: "whatwg", repo: "console", number: 5 }]);
+  expect(mockGet.mock.calls[0]).toEqual([{ owner: "whatwg", repo: "console", pull_number: 5 }]);
 
   expect(mockCreateStatus).toHaveBeenCalledTimes(1);
   expect(mockCreateStatus.mock.calls[0]).toMatchSnapshot();
@@ -56,7 +56,7 @@ test("A PR from a fork must trigger an appropriate status update", async () => {
   await updatePR("https://github.com/whatwg/console/pull/6");
 
   expect(mockGet).toHaveBeenCalledTimes(1);
-  expect(mockGet.mock.calls[0]).toEqual([{ owner: "whatwg", repo: "console", number: 6 }]);
+  expect(mockGet.mock.calls[0]).toEqual([{ owner: "whatwg", repo: "console", pull_number: 6 }]);
 
   expect(mockCreateStatus).toHaveBeenCalledTimes(1);
   expect(mockCreateStatus.mock.calls[0]).toMatchSnapshot();
@@ -68,7 +68,7 @@ test("A PR with a hash at the end must still trigger an appropriate status updat
   await updatePR("https://github.com/whatwg/console/pull/131#issuecomment-376766631");
 
   expect(mockGet).toHaveBeenCalledTimes(1);
-  expect(mockGet.mock.calls[0]).toEqual([{ owner: "whatwg", repo: "console", number: 131 }]);
+  expect(mockGet.mock.calls[0]).toEqual([{ owner: "whatwg", repo: "console", pull_number: 131 }]);
 
   expect(mockCreateStatus).toHaveBeenCalledTimes(1);
   expect(mockCreateStatus.mock.calls[0]).toMatchSnapshot();
@@ -80,7 +80,7 @@ test("A PR with /files at the end must still trigger an appropriate status updat
   await updatePR("https://github.com/whatwg/console/pull/131/files");
 
   expect(mockGet).toHaveBeenCalledTimes(1);
-  expect(mockGet.mock.calls[0]).toEqual([{ owner: "whatwg", repo: "console", number: 131 }]);
+  expect(mockGet.mock.calls[0]).toEqual([{ owner: "whatwg", repo: "console", pull_number: 131 }]);
 
   expect(mockCreateStatus).toHaveBeenCalledTimes(1);
   expect(mockCreateStatus.mock.calls[0]).toMatchSnapshot();
@@ -92,7 +92,7 @@ test("A PR with /commits at the end must still trigger an appropriate status upd
   await updatePR("https://github.com/whatwg/console/pull/131/commits");
 
   expect(mockGet).toHaveBeenCalledTimes(1);
-  expect(mockGet.mock.calls[0]).toEqual([{ owner: "whatwg", repo: "console", number: 131 }]);
+  expect(mockGet.mock.calls[0]).toEqual([{ owner: "whatwg", repo: "console", pull_number: 131 }]);
 
   expect(mockCreateStatus).toHaveBeenCalledTimes(1);
   expect(mockCreateStatus.mock.calls[0]).toMatchSnapshot();

--- a/lib/pr-webhook.js
+++ b/lib/pr-webhook.js
@@ -31,8 +31,8 @@ module.exports = async body => {
 
 async function prExists(pr) {
   try {
-    await gitHubAPI.pullRequests.get({
-      number: pr.number,
+    await gitHubAPI.pulls.get({
+      pull_number: pr.number,
       owner: pr.base.repo.owner.login,
       repo: pr.base.repo.name,
       method: "HEAD"

--- a/lib/update-pr.js
+++ b/lib/update-pr.js
@@ -8,7 +8,7 @@ const repos = config.workstreams.map(workstream => workstream.id).join("|");
 
 module.exports = async url => {
   const prLocation = getPRLocation(url);
-  const pr = (await gitHubAPI.pullRequests.get(prLocation)).data;
+  const pr = (await gitHubAPI.pulls.get(prLocation)).data;
 
   if (pr.merged_at) {
     throw new Forbidden("Cannot update pull requests that have been merged; their status must " +
@@ -39,6 +39,6 @@ function getPRLocation(url) {
   return {
     owner: config.specOrg,
     repo: match[1],
-    number: Number(match[2])
+    pull_number: Number(match[2])
   };
 }


### PR DESCRIPTION
These were missed in 8704ab0909775ca1f6e0a8264718528b3573e6e4 and 33f3eb6ef3a4c0e43a9bc7cec5a52dd14ed15523, and not caught because we only had unit tests, which mocked out the GitHub API.