### PR TITLE
Fix agreement submission after Octokit upgrade

### DIFF
--- a/lib/helpers/json-github-database.js
+++ b/lib/helpers/json-github-database.js
@@ -4,19 +4,17 @@ const { api, locationFromType } = require("./github.js");
 
 exports.update = async (type, commitMessage, previousSHA, contents) => {
   const location = locationFromType(type);
+
   const options = Object.assign({
     message: commitMessage,
     content: serializeForAPI(contents),
     committer: privateConfig.gitHub.committer
   }, location);
-
-  let method = "createFile";
   if (previousSHA) {
     options.sha = previousSHA;
-    method = "updateFile";
   }
 
-  await api.repos[method](options);
+  await api.repos.createOrUpdateFile(options);
 };
 
 exports.get = async type => {
@@ -26,7 +24,7 @@ exports.get = async type => {
   try {
     result = await api.repos.getContents(location);
   } catch (e) {
-    if (e.code === 404) {
+    if (e.status === 404) {
       return {
         sha: null,
         content: []

--- a/lib/server-infra/error-handler.js
+++ b/lib/server-infra/error-handler.js
@@ -12,10 +12,10 @@ module.exports = async (ctx, next) => {
       ctx.throw(404);
     }
   } catch (err) {
-    ctx.status = typeof err.status === "number" ? err.status : 500;
+    ctx.status = typeof err.status === "number" && !isOctokitError(err) ? err.status : 500;
 
     if (ctx.status === 500) {
-      console.error(err.stack || err);
+      console.error(err.stack, err);
     }
 
     const statusMessage = STATUS_CODES[ctx.status];
@@ -38,3 +38,10 @@ module.exports = async (ctx, next) => {
     }
   }
 };
+
+// Octokit uses HttpError too, and these can bubble to us.
+// But if one of these reaches us, it's an internal server error, and should not be communicated as
+// whatever status code the GitHub API returned.
+function isOctokitError(err) {
+  return err.documentation_url && err.documentation_url.startsWith("https://developer.github.com/");
+}


### PR DESCRIPTION
This is yet another fallout from 20b1121c8efb31b082422dfdf5ae069438fe2284, which was missed due to our unit tests which mock out the GitHub API.

Closes #92.