### PR TITLE
Switch from postinstall to prepare script for sg/db.json dependency

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -16,7 +16,7 @@ if [[ "$TRAVIS_BRANCH" != "master" || "$TRAVIS_PULL_REQUEST" != "false" ]]; then
   exit 0
 fi
 
-# Grab the sg/ repo
+# Grab the sg/ repo, as `npm install --production` will not run the prepare script.
 npm run update-sg
 
 # Get the deploy key by using Travis's stored variables to decrypt deploy_key.enc

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node lib/app.js",
     "lint": "eslint .",
-    "postinstall": "npm run update-sg",
+    "prepare": "npm run update-sg",
     "test": "jest",
     "update-sg": "git clone \"https://github.com/whatwg/sg.git\" \"sg\" || git -C \"sg\" pull",
     "coverage": "jest --coverage"


### PR DESCRIPTION
The prepare script is intended for this type of thing:
https://docs.npmjs.com/misc/scripts#prepublish-and-prepare

A non-obvious and seemingly undocumented feature is important here:
`npm install --production` won't run the prepare script. If it did, we
wouldn't need `npm run update-sg` in the deploy.sh script.

Fixes the issue described in https://github.com/whatwg/participate.whatwg.org/pull/113#issuecomment-645262103.