### PR TITLE
Workstreams and repositories are not 1:1

### DIFF
--- a/__tests__/workstreams.js
+++ b/__tests__/workstreams.js
@@ -1,0 +1,52 @@
+"use strict";
+
+jest.mock("../sg/db.json", () => {
+  return {
+    workstreams: [
+      {
+        id: "workstream1",
+        name: "Workstream 1",
+        standards: [
+          {
+            href: "https://standard1.spec.whatwg.org/"
+          }
+        ]
+      },
+      {
+        id: "workstream2",
+        name: "Workstream 2",
+        standards: [
+          {
+            href: "https://standard2.spec.whatwg.org/"
+          },
+          {
+            href: "https://standard3.spec.whatwg.org/"
+          }
+        ]
+      }
+    ]
+  };
+}, { virtual: true });
+
+const workstreams = require("../lib/helpers/workstreams.js");
+
+test("repos", () => {
+  expect(workstreams.repos).toEqual(["standard1", "standard2", "standard3"]);
+});
+
+test("workstreamFromRepo, for a one-standard workstream", () => {
+  const result = workstreams.workstreamFromRepo("standard1");
+  expect(result.id).toEqual("workstream1");
+});
+
+test("workstreamFromRepo, for a two-standard workstream", () => {
+  const result1 = workstreams.workstreamFromRepo("standard2");
+  expect(result1.id).toEqual("workstream2");
+
+  const result2 = workstreams.workstreamFromRepo("standard3");
+  expect(result2.id).toEqual("workstream2");
+});
+
+test("workstreamFromRepo, for an invalid repo", () => {
+  expect(() => workstreams.workstreamFromRepo("not-a-standard")).toThrow();
+});

--- a/lib/get-user-status.js
+++ b/lib/get-user-status.js
@@ -20,7 +20,8 @@ module.exports = async (submitterGitHubID, repoName) => {
     // Using .toLowerCase() is safe because GitHub usernames only allow ASCII.
     if (individual.info.gitHubID.toLowerCase() === submitterGitHubID.toLowerCase()) {
       if (individual.verified) {
-        if (individual.workstreams === "all" || individual.workstreams.includes(getWorkstream(repoName).id)) {
+        if (individual.workstreams === "all" ||
+            individual.workstreams.includes(getWorkstream(repoName).id)) {
           return statusIndividual(submitterGitHubID, repoName);
         }
         return statusIndividualNoWorkstreams(submitterGitHubID, repoName);

--- a/lib/get-user-status.js
+++ b/lib/get-user-status.js
@@ -20,7 +20,7 @@ module.exports = async (submitterGitHubID, repoName) => {
     // Using .toLowerCase() is safe because GitHub usernames only allow ASCII.
     if (individual.info.gitHubID.toLowerCase() === submitterGitHubID.toLowerCase()) {
       if (individual.verified) {
-        if (individual.workstreams === "all" || individual.workstreams.includes(repoName)) {
+        if (individual.workstreams === "all" || individual.workstreams.includes(getWorkstream(repoName).id)) {
           return statusIndividual(submitterGitHubID, repoName);
         }
         return statusIndividualNoWorkstreams(submitterGitHubID, repoName);
@@ -48,7 +48,7 @@ module.exports = async (submitterGitHubID, repoName) => {
     }
 
     for (const entity of verifiedEntities) {
-      if (entity.workstreams === "all" || entity.workstreams.includes(repoName)) {
+      if (entity.workstreams === "all" || entity.workstreams.includes(getWorkstream(repoName).id)) {
         return statusEntity(submitterGitHubID, repoName, entity);
       }
     }
@@ -77,7 +77,7 @@ function statusIndividual(submitterGitHubID, repoName) {
 }
 
 function statusIndividualNoWorkstreams(submitterGitHubID, repoName) {
-  const workstreamName = getWorkstreamName(repoName);
+  const workstreamName = getWorkstream(repoName).name;
   const repo = config.publicDataRepo.owner + "/" + config.publicDataRepo.name;
 
   return {
@@ -104,7 +104,7 @@ function statusIndividualUnverified(submitterGitHubID, repoName) {
 }
 
 function statusEntity(submitterGitHubID, repoName, entity) {
-  const workstreamName = getWorkstreamName(repoName);
+  const workstreamName = getWorkstream(repoName).name;
 
   return {
     state: "success",
@@ -133,7 +133,7 @@ function statusEntitiesUnverified(submitterGitHubID, repoName, entities) {
 
 function statusEntityNoWorkstreams(submitterGitHubID, repoName, entities) {
   const { orgs, word, pronoun, pronoun2, doVerb } = entityVerbiage(entities);
-  const workstreamName = getWorkstreamName(repoName);
+  const workstreamName = getWorkstream(repoName).name;
 
   return {
     state: "pending",
@@ -178,6 +178,17 @@ async function isOrgMember(org, username) {
   }
 }
 
-function getWorkstreamName(repoName) {
-  return workstreamsData.find(workstream => workstream.id === repoName).name;
+function getWorkstream(repoName) {
+  for (const workstream of workstreamsData) {
+    for (const standard of workstream.standards) {
+      if (getShortname(standard.href) === repoName) {
+        return workstream;
+      }
+    }
+  }
+  throw Error(`${repoName} not associated with a Workstream.`);
+}
+
+function getShortname(standardHref) {
+  return standardHref.slice("https://".length, standardHref.indexOf("."));
 }

--- a/lib/get-user-status.js
+++ b/lib/get-user-status.js
@@ -2,8 +2,8 @@
 const { URL } = require("url");
 const listify = require("listify");
 const config = require("../config.json");
-const workstreamsData = require("../sg/db.json").workstreams;
 const gitHubAPI = require("./helpers/github.js").api;
+const { workstreamFromRepo } = require("./helpers/workstreams.js");
 const jsonGitHubDatabase = require("./helpers/json-github-database.js");
 const html = require("escape-goat").htmlEscape;
 
@@ -21,7 +21,7 @@ module.exports = async (submitterGitHubID, repoName) => {
     if (individual.info.gitHubID.toLowerCase() === submitterGitHubID.toLowerCase()) {
       if (individual.verified) {
         if (individual.workstreams === "all" ||
-            individual.workstreams.includes(getWorkstream(repoName).id)) {
+            individual.workstreams.includes(workstreamFromRepo(repoName).id)) {
           return statusIndividual(submitterGitHubID, repoName);
         }
         return statusIndividualNoWorkstreams(submitterGitHubID, repoName);
@@ -49,7 +49,8 @@ module.exports = async (submitterGitHubID, repoName) => {
     }
 
     for (const entity of verifiedEntities) {
-      if (entity.workstreams === "all" || entity.workstreams.includes(getWorkstream(repoName).id)) {
+      if (entity.workstreams === "all" ||
+          entity.workstreams.includes(workstreamFromRepo(repoName).id)) {
         return statusEntity(submitterGitHubID, repoName, entity);
       }
     }
@@ -78,7 +79,7 @@ function statusIndividual(submitterGitHubID, repoName) {
 }
 
 function statusIndividualNoWorkstreams(submitterGitHubID, repoName) {
-  const workstreamName = getWorkstream(repoName).name;
+  const workstreamName = workstreamFromRepo(repoName).name;
   const repo = config.publicDataRepo.owner + "/" + config.publicDataRepo.name;
 
   return {
@@ -105,7 +106,7 @@ function statusIndividualUnverified(submitterGitHubID, repoName) {
 }
 
 function statusEntity(submitterGitHubID, repoName, entity) {
-  const workstreamName = getWorkstream(repoName).name;
+  const workstreamName = workstreamFromRepo(repoName).name;
 
   return {
     state: "success",
@@ -134,7 +135,7 @@ function statusEntitiesUnverified(submitterGitHubID, repoName, entities) {
 
 function statusEntityNoWorkstreams(submitterGitHubID, repoName, entities) {
   const { orgs, word, pronoun, pronoun2, doVerb } = entityVerbiage(entities);
-  const workstreamName = getWorkstream(repoName).name;
+  const workstreamName = workstreamFromRepo(repoName).name;
 
   return {
     state: "pending",
@@ -177,19 +178,4 @@ async function isOrgMember(org, username) {
   } catch (e) {
     return false;
   }
-}
-
-function getWorkstream(repoName) {
-  for (const workstream of workstreamsData) {
-    for (const standard of workstream.standards) {
-      if (getShortname(standard.href) === repoName) {
-        return workstream;
-      }
-    }
-  }
-  throw Error(`${repoName} not associated with a Workstream.`);
-}
-
-function getShortname(standardHref) {
-  return standardHref.slice("https://".length, standardHref.indexOf("."));
 }

--- a/lib/helpers/workstreams.js
+++ b/lib/helpers/workstreams.js
@@ -1,0 +1,22 @@
+"use strict";
+const workstreamsData = require("../../sg/db.json").workstreams;
+
+exports.repos = workstreamsData
+  .flatMap(workstream => workstream.standards)
+  .map(standard => getShortname(standard.href));
+
+exports.workstreamFromRepo = repoName => {
+  for (const workstream of workstreamsData) {
+    for (const standard of workstream.standards) {
+      if (getShortname(standard.href) === repoName) {
+        return workstream;
+      }
+    }
+  }
+
+  throw new Error(`${repoName} not associated with a Workstream.`);
+};
+
+function getShortname(standardHref) {
+  return standardHref.slice("https://".length, standardHref.indexOf("."));
+}

--- a/lib/update-pr.js
+++ b/lib/update-pr.js
@@ -3,10 +3,7 @@ const { BadRequest, Forbidden } = require("http-errors");
 const gitHubAPI = require("./helpers/github.js").api;
 const getUserStatus = require("./get-user-status.js");
 const config = require("../config.json");
-const workstreamsData = require("../sg/db.json").workstreams;
-
-const repos = workstreamsData.flatMap(workstream => workstream.standards)
-                             .map(standard => getShortname(standard.href)).join("|");
+const { repos } = require("./helpers/workstreams.js");
 
 module.exports = async url => {
   const prLocation = getPRLocation(url);
@@ -29,7 +26,7 @@ module.exports = async url => {
 function getPRLocation(url) {
   // URL will have been parsed and serialized by now, so this is reasonable to do.
   const re = new RegExp(
-    `^https://github.com/${config.specOrg}/(${repos})/pull/([1-9][0-9]*)(?:/[^/]+)?(?:#.*)?$`);
+    `^https://github.com/${config.specOrg}/(${repos.join("|")})/pull/([1-9][0-9]*)(?:/[^/]+)?(?:#.*)?$`);
   const match = re.exec(url);
 
   if (match === null) {
@@ -43,8 +40,4 @@ function getPRLocation(url) {
     repo: match[1],
     pull_number: Number(match[2])
   };
-}
-
-function getShortname(standardHref) {
-  return standardHref.slice("https://".length, standardHref.indexOf("."));
 }

--- a/lib/update-pr.js
+++ b/lib/update-pr.js
@@ -5,7 +5,7 @@ const getUserStatus = require("./get-user-status.js");
 const config = require("../config.json");
 const workstreamsData = require("../sg/db.json").workstreams;
 
-const repos = workstreamsData.map(workstream => workstream.id).join("|");
+const repos = workstreamsData.flatMap(workstream => workstream.standards).map(standard => getShortname(standard.href)).join("|");
 
 module.exports = async url => {
   const prLocation = getPRLocation(url);
@@ -42,4 +42,8 @@ function getPRLocation(url) {
     repo: match[1],
     pull_number: Number(match[2])
   };
+}
+
+function getShortname(standardHref) {
+  return standardHref.slice("https://".length, standardHref.indexOf("."));
 }

--- a/lib/update-pr.js
+++ b/lib/update-pr.js
@@ -5,7 +5,8 @@ const getUserStatus = require("./get-user-status.js");
 const config = require("../config.json");
 const workstreamsData = require("../sg/db.json").workstreams;
 
-const repos = workstreamsData.flatMap(workstream => workstream.standards).map(standard => getShortname(standard.href)).join("|");
+const repos = workstreamsData.flatMap(workstream => workstream.standards)
+                             .map(standard => getShortname(standard.href)).join("|");
 
 module.exports = async url => {
   const prLocation = getPRLocation(url);


### PR DESCRIPTION
We probably want to deduplicate the `getShortname()` function? Should we create a workstream module that exports workstreams and these helper methods? I'm also happy for you to take this over as that will probably go a bit quicker.

(I looked at 6a04d97573f343f25f79de993ba6dda4d00f749d to see what needed to be adjusted. It seems like we do want to keep the `id` field for the database. It's just that we cannot use that to map to a repo directly.)

Fixes #159.