### PR TITLE
Add more tests for tweet-webhook.js

### DIFF
--- a/__tests__/__fixtures__/push-to-branch.json
+++ b/__tests__/__fixtures__/push-to-branch.json
@@ -1,0 +1,205 @@
+{
+  "ref": "refs/heads/yhirano/streaming-upload-sw",
+  "before": "1ebeb029023ce27c48544026ddec165697f27079",
+  "after": "847abbc5bf48ab6032bb437bbb9386cfb29b0f39",
+  "repository": {
+    "id": 5777189,
+    "node_id": "MDEwOlJlcG9zaXRvcnk1Nzc3MTg5",
+    "name": "fetch",
+    "full_name": "whatwg/fetch",
+    "private": false,
+    "owner": {
+      "name": "whatwg",
+      "email": null,
+      "login": "whatwg",
+      "id": 2226336,
+      "node_id": "MDEyOk9yZ2FuaXphdGlvbjIyMjYzMzY=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2226336?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/whatwg",
+      "html_url": "https://github.com/whatwg",
+      "followers_url": "https://api.github.com/users/whatwg/followers",
+      "following_url": "https://api.github.com/users/whatwg/following{/other_user}",
+      "gists_url": "https://api.github.com/users/whatwg/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/whatwg/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/whatwg/subscriptions",
+      "organizations_url": "https://api.github.com/users/whatwg/orgs",
+      "repos_url": "https://api.github.com/users/whatwg/repos",
+      "events_url": "https://api.github.com/users/whatwg/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/whatwg/received_events",
+      "type": "Organization",
+      "site_admin": false
+    },
+    "html_url": "https://github.com/whatwg/fetch",
+    "description": "Fetch Standard",
+    "fork": false,
+    "url": "https://github.com/whatwg/fetch",
+    "forks_url": "https://api.github.com/repos/whatwg/fetch/forks",
+    "keys_url": "https://api.github.com/repos/whatwg/fetch/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/whatwg/fetch/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/whatwg/fetch/teams",
+    "hooks_url": "https://api.github.com/repos/whatwg/fetch/hooks",
+    "issue_events_url": "https://api.github.com/repos/whatwg/fetch/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/whatwg/fetch/events",
+    "assignees_url": "https://api.github.com/repos/whatwg/fetch/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/whatwg/fetch/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/whatwg/fetch/tags",
+    "blobs_url": "https://api.github.com/repos/whatwg/fetch/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/whatwg/fetch/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/whatwg/fetch/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/whatwg/fetch/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/whatwg/fetch/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/whatwg/fetch/languages",
+    "stargazers_url": "https://api.github.com/repos/whatwg/fetch/stargazers",
+    "contributors_url": "https://api.github.com/repos/whatwg/fetch/contributors",
+    "subscribers_url": "https://api.github.com/repos/whatwg/fetch/subscribers",
+    "subscription_url": "https://api.github.com/repos/whatwg/fetch/subscription",
+    "commits_url": "https://api.github.com/repos/whatwg/fetch/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/whatwg/fetch/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/whatwg/fetch/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/whatwg/fetch/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/whatwg/fetch/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/whatwg/fetch/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/whatwg/fetch/merges",
+    "archive_url": "https://api.github.com/repos/whatwg/fetch/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/whatwg/fetch/downloads",
+    "issues_url": "https://api.github.com/repos/whatwg/fetch/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/whatwg/fetch/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/whatwg/fetch/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/whatwg/fetch/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/whatwg/fetch/labels{/name}",
+    "releases_url": "https://api.github.com/repos/whatwg/fetch/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/whatwg/fetch/deployments",
+    "created_at": 1347439160,
+    "updated_at": "2021-01-27T09:09:18Z",
+    "pushed_at": 1611835266,
+    "git_url": "git://github.com/whatwg/fetch.git",
+    "ssh_url": "git@github.com:whatwg/fetch.git",
+    "clone_url": "https://github.com/whatwg/fetch.git",
+    "svn_url": "https://github.com/whatwg/fetch",
+    "homepage": "https://fetch.spec.whatwg.org/",
+    "size": 7576,
+    "stargazers_count": 1651,
+    "watchers_count": 1651,
+    "language": "HTML",
+    "has_issues": true,
+    "has_projects": false,
+    "has_downloads": true,
+    "has_wiki": false,
+    "has_pages": false,
+    "forks_count": 232,
+    "mirror_url": null,
+    "archived": false,
+    "disabled": false,
+    "open_issues_count": 224,
+    "license": {
+      "key": "cc-by-4.0",
+      "name": "Creative Commons Attribution 4.0 International",
+      "spdx_id": "CC-BY-4.0",
+      "url": "https://api.github.com/licenses/cc-by-4.0",
+      "node_id": "MDc6TGljZW5zZTI1"
+    },
+    "forks": 232,
+    "open_issues": 224,
+    "watchers": 1651,
+    "default_branch": "main",
+    "stargazers": 1651,
+    "master_branch": "main",
+    "organization": "whatwg"
+  },
+  "pusher": {
+    "name": "yutakahirano",
+    "email": "yhirano@google.com"
+  },
+  "organization": {
+    "login": "whatwg",
+    "id": 2226336,
+    "node_id": "MDEyOk9yZ2FuaXphdGlvbjIyMjYzMzY=",
+    "url": "https://api.github.com/orgs/whatwg",
+    "repos_url": "https://api.github.com/orgs/whatwg/repos",
+    "events_url": "https://api.github.com/orgs/whatwg/events",
+    "hooks_url": "https://api.github.com/orgs/whatwg/hooks",
+    "issues_url": "https://api.github.com/orgs/whatwg/issues",
+    "members_url": "https://api.github.com/orgs/whatwg/members{/member}",
+    "public_members_url": "https://api.github.com/orgs/whatwg/public_members{/member}",
+    "avatar_url": "https://avatars.githubusercontent.com/u/2226336?v=4",
+    "description": "Please leave your sense of logic at the door. All are welcome to participate."
+  },
+  "sender": {
+    "login": "yutakahirano",
+    "id": 5187874,
+    "node_id": "MDQ6VXNlcjUxODc4NzQ=",
+    "avatar_url": "https://avatars.githubusercontent.com/u/5187874?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/yutakahirano",
+    "html_url": "https://github.com/yutakahirano",
+    "followers_url": "https://api.github.com/users/yutakahirano/followers",
+    "following_url": "https://api.github.com/users/yutakahirano/following{/other_user}",
+    "gists_url": "https://api.github.com/users/yutakahirano/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/yutakahirano/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/yutakahirano/subscriptions",
+    "organizations_url": "https://api.github.com/users/yutakahirano/orgs",
+    "repos_url": "https://api.github.com/users/yutakahirano/repos",
+    "events_url": "https://api.github.com/users/yutakahirano/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/yutakahirano/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/whatwg/fetch/compare/1ebeb029023c...847abbc5bf48",
+  "commits": [
+    {
+      "id": "847abbc5bf48ab6032bb437bbb9386cfb29b0f39",
+      "tree_id": "9a03650bc468499faeeb3808a97abea99cc4a145",
+      "distinct": true,
+      "message": "fix",
+      "timestamp": "2021-01-28T21:00:42+09:00",
+      "url": "https://github.com/whatwg/fetch/commit/847abbc5bf48ab6032bb437bbb9386cfb29b0f39",
+      "author": {
+        "name": "Yutaka Hirano",
+        "email": "yhirano@chrmomium.org"
+      },
+      "committer": {
+        "name": "Yutaka Hirano",
+        "email": "yhirano@chrmomium.org"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "fetch.bs"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "847abbc5bf48ab6032bb437bbb9386cfb29b0f39",
+    "tree_id": "9a03650bc468499faeeb3808a97abea99cc4a145",
+    "distinct": true,
+    "message": "fix",
+    "timestamp": "2021-01-28T21:00:42+09:00",
+    "url": "https://github.com/whatwg/fetch/commit/847abbc5bf48ab6032bb437bbb9386cfb29b0f39",
+    "author": {
+      "name": "Yutaka Hirano",
+      "email": "yhirano@chrmomium.org"
+    },
+    "committer": {
+      "name": "Yutaka Hirano",
+      "email": "yhirano@chrmomium.org"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "fetch.bs"
+    ]
+  }
+}

--- a/__tests__/__fixtures__/push-to-main-meta.json
+++ b/__tests__/__fixtures__/push-to-main-meta.json
@@ -1,0 +1,209 @@
+{
+  "ref": "refs/heads/main",
+  "before": "ecd23cff2c495741eb007ed3ec15d3a45b52fe52",
+  "after": "48f6b2871cd6d1899644ac819ab877f6688d8a6f",
+  "repository": {
+    "id": 11969507,
+    "node_id": "MDEwOlJlcG9zaXRvcnkxMTk2OTUwNw==",
+    "name": "html",
+    "full_name": "whatwg/html",
+    "private": false,
+    "owner": {
+      "name": "whatwg",
+      "email": null,
+      "login": "whatwg",
+      "id": 2226336,
+      "node_id": "MDEyOk9yZ2FuaXphdGlvbjIyMjYzMzY=",
+      "avatar_url": "https://avatars.githubusercontent.com/u/2226336?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/whatwg",
+      "html_url": "https://github.com/whatwg",
+      "followers_url": "https://api.github.com/users/whatwg/followers",
+      "following_url": "https://api.github.com/users/whatwg/following{/other_user}",
+      "gists_url": "https://api.github.com/users/whatwg/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/whatwg/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/whatwg/subscriptions",
+      "organizations_url": "https://api.github.com/users/whatwg/orgs",
+      "repos_url": "https://api.github.com/users/whatwg/repos",
+      "events_url": "https://api.github.com/users/whatwg/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/whatwg/received_events",
+      "type": "Organization",
+      "site_admin": false
+    },
+    "html_url": "https://github.com/whatwg/html",
+    "description": "HTML Standard",
+    "fork": false,
+    "url": "https://github.com/whatwg/html",
+    "forks_url": "https://api.github.com/repos/whatwg/html/forks",
+    "keys_url": "https://api.github.com/repos/whatwg/html/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/whatwg/html/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/whatwg/html/teams",
+    "hooks_url": "https://api.github.com/repos/whatwg/html/hooks",
+    "issue_events_url": "https://api.github.com/repos/whatwg/html/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/whatwg/html/events",
+    "assignees_url": "https://api.github.com/repos/whatwg/html/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/whatwg/html/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/whatwg/html/tags",
+    "blobs_url": "https://api.github.com/repos/whatwg/html/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/whatwg/html/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/whatwg/html/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/whatwg/html/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/whatwg/html/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/whatwg/html/languages",
+    "stargazers_url": "https://api.github.com/repos/whatwg/html/stargazers",
+    "contributors_url": "https://api.github.com/repos/whatwg/html/contributors",
+    "subscribers_url": "https://api.github.com/repos/whatwg/html/subscribers",
+    "subscription_url": "https://api.github.com/repos/whatwg/html/subscription",
+    "commits_url": "https://api.github.com/repos/whatwg/html/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/whatwg/html/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/whatwg/html/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/whatwg/html/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/whatwg/html/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/whatwg/html/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/whatwg/html/merges",
+    "archive_url": "https://api.github.com/repos/whatwg/html/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/whatwg/html/downloads",
+    "issues_url": "https://api.github.com/repos/whatwg/html/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/whatwg/html/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/whatwg/html/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/whatwg/html/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/whatwg/html/labels{/name}",
+    "releases_url": "https://api.github.com/repos/whatwg/html/releases{/id}",
+    "deployments_url": "https://api.github.com/repos/whatwg/html/deployments",
+    "created_at": 1375943167,
+    "updated_at": "2021-01-28T14:49:54Z",
+    "pushed_at": 1611848564,
+    "git_url": "git://github.com/whatwg/html.git",
+    "ssh_url": "git@github.com:whatwg/html.git",
+    "clone_url": "https://github.com/whatwg/html.git",
+    "svn_url": "https://github.com/whatwg/html",
+    "homepage": "https://html.spec.whatwg.org/multipage/",
+    "size": 245063,
+    "stargazers_count": 4242,
+    "watchers_count": 4242,
+    "language": "HTML",
+    "has_issues": true,
+    "has_projects": false,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": false,
+    "forks_count": 1543,
+    "mirror_url": null,
+    "archived": false,
+    "disabled": false,
+    "open_issues_count": 1453,
+    "license": {
+      "key": "cc-by-4.0",
+      "name": "Creative Commons Attribution 4.0 International",
+      "spdx_id": "CC-BY-4.0",
+      "url": "https://api.github.com/licenses/cc-by-4.0",
+      "node_id": "MDc6TGljZW5zZTI1"
+    },
+    "forks": 1543,
+    "open_issues": 1453,
+    "watchers": 4242,
+    "default_branch": "main",
+    "stargazers": 4242,
+    "master_branch": "main",
+    "organization": "whatwg"
+  },
+  "pusher": {
+    "name": "domenic",
+    "email": "d@domenic.me"
+  },
+  "organization": {
+    "login": "whatwg",
+    "id": 2226336,
+    "node_id": "MDEyOk9yZ2FuaXphdGlvbjIyMjYzMzY=",
+    "url": "https://api.github.com/orgs/whatwg",
+    "repos_url": "https://api.github.com/orgs/whatwg/repos",
+    "events_url": "https://api.github.com/orgs/whatwg/events",
+    "hooks_url": "https://api.github.com/orgs/whatwg/hooks",
+    "issues_url": "https://api.github.com/orgs/whatwg/issues",
+    "members_url": "https://api.github.com/orgs/whatwg/members{/member}",
+    "public_members_url": "https://api.github.com/orgs/whatwg/public_members{/member}",
+    "avatar_url": "https://avatars.githubusercontent.com/u/2226336?v=4",
+    "description": "Please leave your sense of logic at the door. All are welcome to participate."
+  },
+  "sender": {
+    "login": "domenic",
+    "id": 617481,
+    "node_id": "MDQ6VXNlcjYxNzQ4MQ==",
+    "avatar_url": "https://avatars.githubusercontent.com/u/617481?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/domenic",
+    "html_url": "https://github.com/domenic",
+    "followers_url": "https://api.github.com/users/domenic/followers",
+    "following_url": "https://api.github.com/users/domenic/following{/other_user}",
+    "gists_url": "https://api.github.com/users/domenic/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/domenic/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/domenic/subscriptions",
+    "organizations_url": "https://api.github.com/users/domenic/orgs",
+    "repos_url": "https://api.github.com/users/domenic/repos",
+    "events_url": "https://api.github.com/users/domenic/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/domenic/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/whatwg/html/compare/ecd23cff2c49...48f6b2871cd6",
+  "commits": [
+    {
+      "id": "48f6b2871cd6d1899644ac819ab877f6688d8a6f",
+      "tree_id": "1211b786a2c77dfbba7977ffc263ba2ed24b1425",
+      "distinct": true,
+      "message": "Meta: add definition markup for MessageEvent",
+      "timestamp": "2021-01-28T10:42:42-05:00",
+      "url": "https://github.com/whatwg/html/commit/48f6b2871cd6d1899644ac819ab877f6688d8a6f",
+      "author": {
+        "name": "Domenic Denicola",
+        "email": "d@domenic.me",
+        "username": "domenic"
+      },
+      "committer": {
+        "name": "Domenic Denicola",
+        "email": "d@domenic.me",
+        "username": "domenic"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "source"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "48f6b2871cd6d1899644ac819ab877f6688d8a6f",
+    "tree_id": "1211b786a2c77dfbba7977ffc263ba2ed24b1425",
+    "distinct": true,
+    "message": "Meta: add definition markup for MessageEvent",
+    "timestamp": "2021-01-28T10:42:42-05:00",
+    "url": "https://github.com/whatwg/html/commit/48f6b2871cd6d1899644ac819ab877f6688d8a6f",
+    "author": {
+      "name": "Domenic Denicola",
+      "email": "d@domenic.me",
+      "username": "domenic"
+    },
+    "committer": {
+      "name": "Domenic Denicola",
+      "email": "d@domenic.me",
+      "username": "domenic"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "source"
+    ]
+  }
+}

--- a/__tests__/tweet-webhook.js
+++ b/__tests__/tweet-webhook.js
@@ -1,5 +1,7 @@
 "use strict";
 const pushToMain = require("./__fixtures__/push-to-main.json");
+const pushToMainMeta = require("./__fixtures__/push-to-main-meta.json");
+const pushToBranch = require("./__fixtures__/push-to-branch.json");
 
 jest.mock("twitter-lite");
 const Twitter = require("twitter-lite");
@@ -14,6 +16,14 @@ jest.mock("../private-config.json", () => {
       thedomstandard: {
         key: "domstandardkey",
         secret: "domstandardsecret"
+      },
+      htmlstandard: {
+        key: "htmlstandardkey",
+        secret: "htmlstandardsecret"
+      },
+      fetchstandard: {
+        key: "fetchstandardkey",
+        secret: "fetchstandardsecret"
       }
     }
   };
@@ -25,7 +35,7 @@ beforeEach(() => {
   Twitter.mockClear();
 });
 
-test("A push to main must trigger a tweet", async () => {
+test("A push to main with a substantive commit must trigger a tweet", async () => {
   await tweetWebhook(pushToMain);
 
   expect(Twitter).toHaveBeenCalledTimes(1);
@@ -44,10 +54,19 @@ test("A push to main must trigger a tweet", async () => {
   );
 });
 
+test("A push to main with a Meta: commit must not trigger a tweet", async () => {
+  await tweetWebhook(pushToMainMeta);
+
+  expect(Twitter).not.toHaveBeenCalled();
+});
+
+test("A push to a non-main branch must not trigger a tweet", async () => {
+  await tweetWebhook(pushToBranch);
+
+  expect(Twitter).not.toHaveBeenCalled();
+});
+
 // Tests to write (easier once we collect some events to paste into __fixtures__):
-// - Pushes to a non-main branch
 // - Push to a main branch but in a non-standard repo
 // - A standard repo with no keys configured should throw an error
 // - Multiple commits in a single event?
-// - Cases where composeTweet returns null?
-//   Should we do that by mocking composeTweet, or by adding redundant coverage?

--- a/lib/tweet-webhook.js
+++ b/lib/tweet-webhook.js
@@ -20,13 +20,6 @@ module.exports = async body => {
     throw new Error(`Keys are not configured for the ${twitter} account.`);
   }
 
-  const client = new Twitter({
-    consumer_key: privateConfig.twitterApp.key,
-    consumer_secret: privateConfig.twitterApp.secret,
-    access_token_key: keys.key,
-    access_token_secret: keys.secret
-  });
-
   for (const commit of body.commits) {
     // The composeTweet function either returns the tweet status or null if the commit does not
     // need a tweet. Given that the tweet status is composed of maximum 70 characters, plus a thank
@@ -36,6 +29,13 @@ module.exports = async body => {
     if (!tweetStatus) {
       continue;
     }
+
+    const client = new Twitter({
+      consumer_key: privateConfig.twitterApp.key,
+      consumer_secret: privateConfig.twitterApp.secret,
+      access_token_key: keys.key,
+      access_token_secret: keys.secret
+    });
 
     await client.post("statuses/update", { status: tweetStatus });
   }

--- a/lib/tweet-webhook.js
+++ b/lib/tweet-webhook.js
@@ -30,6 +30,8 @@ module.exports = async body => {
       continue;
     }
 
+    // Keeping this inside the loop (and after the above `if`) makes testing easier since we can
+    // just assert whether or not the `Twitter` constructor was called.
     const client = new Twitter({
       consumer_key: privateConfig.twitterApp.key,
       consumer_secret: privateConfig.twitterApp.secret,


### PR DESCRIPTION
I was a bit annoyed at how the test forced me to change the code (by moving the `new Twitter()` construction inside the loop), but it seemed clean enough. The alternative would be changing the test condition to be intentionally more vague: something like

```js
if (Twitter.mock.instances[0]) {
  expect(Twitter.mock.instances[0].post).not.toHaveBeenCalled();
}
// Otherwise, it was never constructed, which is also a good outcome.
```

I could go either way.