### PR TITLE
Send the appropriate headers as expected by misc-server tests

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -25,7 +25,7 @@ test("responds to requests to the homepage", async () => {
   expect(body).toContain("participate in the WHATWG");
 });
 
-test.only("send the expected headers", async () => {
+test("send the expected headers", async () => {
   const url = `http://127.0.0.1:${server.address().port}/`;
 
   const res = await fetch(url);

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -25,6 +25,18 @@ test("responds to requests to the homepage", async () => {
   expect(body).toContain("participate in the WHATWG");
 });
 
+test.only("send the expected headers", async () => {
+  const url = `http://127.0.0.1:${server.address().port}/`;
+
+  const res = await fetch(url);
+  expect(res.status).toEqual(200);
+
+  expect(res.headers.get("strict-transport-security"))
+    .toEqual("max-age=63072000; includeSubDomains; preload");
+  expect(res.headers.get("x-content-type-options")).toEqual("nosniff");
+  expect(res.headers.get("x-frame-options")).toEqual("deny");
+});
+
 test("/agreement-status throws appropriate error for incorrect pull parameter", async () => {
   const url = `http://127.0.0.1:${server.address().port}/agreement-status?user=test&repo=test&pull=<script>alert(1)</script>`;
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -10,6 +10,7 @@ const routes = require("./routes.js");
 
 const errorHandler = require("./server-infra/error-handler.js");
 const handlebarsSectionHelper = require("./server-infra/handlebars-section-helper.js");
+const headers = require("./server-infra/headers.js");
 
 const app = new Koa();
 const router = new KoaRouter();
@@ -29,6 +30,7 @@ app
     }
   }))
   .use(errorHandler)
+  .use(headers)
   .use(router.routes())
   .use(router.allowedMethods());
 

--- a/lib/server-infra/headers.js
+++ b/lib/server-infra/headers.js
@@ -1,0 +1,10 @@
+"use strict";
+
+module.exports = async (ctx, next) => {
+  // These headers should be kept (mostly) in sync with configuration and tests
+  // in https://github.com/whatwg/misc-server.
+  ctx.set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
+  ctx.set("X-Content-Type-Options", "nosniff");
+  ctx.set("X-Frame-Options", "deny");
+  await next();
+};


### PR DESCRIPTION
There does not appear to be a way to configure DigitalOcean Apps to
always sent some headers (other than CORS) so built it into the app
directly.