### PR TITLE
Manually bump Node to 14.16.1-buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.16.0-buster-slim
+FROM node:14.16.1-buster-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
See https://github.com/dependabot/dependabot-core/issues/2247 for why this is necessary. Closes #197.