### PR TITLE
Manually update node:14.17.4-buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.0-buster-slim
+FROM node:14.17.4-buster-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Closes #220. See https://github.com/dependabot/dependabot-core/issues/2247 for why this is necessary.