### PR TITLE
Manually update to node:14.18.1-buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.6-buster-slim
+FROM node:14.18.1-buster-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Closes #235. See dependabot/dependabot-core#2247 for why this is necessary.