### PR TITLE
Manually update to node:16.15.0-buster-slim

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: 14
+        node-version: 16
     - run: npm install
     - run: npm run lint
     - run: npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.2-buster-slim
+FROM node:16.15.0-buster-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Closes #273. See https://github.com/dependabot/dependabot-core/issues/2247 for why this is necessary.