### PR TITLE
Fix #280. Fix case check for tweets.

### DIFF
--- a/lib/compose-tweet.js
+++ b/lib/compose-tweet.js
@@ -2,8 +2,9 @@
 
 module.exports = (commit, standard) => {
   let [commitTitle] = commit.message.split("\n");
-  for (const exclude of ["Editorial", "Meta", "Review Draft Publication"]) {
-    if (commitTitle.startsWith(`${exclude}:`)) {
+  for (const exclude of ["editorial", "meta", "review draft publication"]) {
+    const lowerTitle = commitTitle.toLowerCase();
+    if (lowerTitle.startsWith(`${exclude}:`)) {
       return null;
     }
   }


### PR DESCRIPTION
fix #280.

to avoid editorial misspelled tweets with wrong casing
See also https://github.com/whatwg/meta/issues/251