### PR TITLE
Manually update to node:16.17.1-buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.17.0-buster-slim
+FROM node:16.17.1-buster-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
See dependabot/dependabot-core#2247 for why this is necessary.

Closes #300.