### PR TITLE
Remove usage of uuid module

### DIFF
--- a/__tests__/process-agreement.js
+++ b/__tests__/process-agreement.js
@@ -1,9 +1,10 @@
 "use strict";
 
 // Fake the UUID generator so it is deterministic for snapshot testing.
-jest.mock("uuid", () => {
+jest.mock("crypto", () => {
   return {
-    v4() {
+    ...jest.requireActual("crypto"),
+    randomUUID() {
       return "1d8ab899-4d91-48b8-acfa-bf9cde5ad909";
     }
   };

--- a/lib/process-agreement.js
+++ b/lib/process-agreement.js
@@ -1,6 +1,6 @@
 "use strict";
 const { URL } = require("url");
-const uuidv4 = require("uuid").v4;
+const { randomUUID } = require("crypto");
 const { BadRequest } = require("http-errors");
 const workstreamsData = require("../sg/db.json").workstreams;
 const gitHubIDRegExp = require("github-username-regex");
@@ -8,7 +8,7 @@ const gitHubIDRegExp = require("github-username-regex");
 const allWorkstreamIDs = new Set(workstreamsData.map(workstream => workstream.id));
 
 module.exports = body => {
-  const id = uuidv4();
+  const id = randomUUID();
   const type = getType(body);
 
   const publicData = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,7 @@
         "koa-bodyparser": "^4.4.1",
         "koa-handlebars": "^2.0.0",
         "listify": "^1.0.3",
-        "twitter-api-v2": "^1.15.1",
-        "uuid": "^9.0.0"
+        "twitter-api-v2": "^1.15.1"
       },
       "devDependencies": {
         "eslint": "^8.48.0",
@@ -5408,14 +5407,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -9591,11 +9582,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -26,15 +26,11 @@
     "koa-bodyparser": "^4.4.1",
     "koa-handlebars": "^2.0.0",
     "listify": "^1.0.3",
-    "twitter-api-v2": "^1.15.1",
-    "uuid": "^9.0.0"
+    "twitter-api-v2": "^1.15.1"
   },
   "devDependencies": {
     "eslint": "^8.48.0",
     "jest": "^29.6.4",
     "minipass-fetch": "^3.0.4"
-  },
-  "volta": {
-    "node": "16.13.0"
   }
 }


### PR DESCRIPTION
It's no longer necessary as UUIDs are built into Node since v14. Closes #365.