### PR TITLE
Link to instructions for unverified individuals and entities

### DIFF
--- a/__tests__/__snapshots__/get-user-status.js.snap
+++ b/__tests__/__snapshots__/get-user-status.js.snap
@@ -247,7 +247,7 @@ exports[`Multiple entities, all unverified 1`] = `
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso1 and contoso2 GitHub organizations, but they all have not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
+  "longDescription": "@johndoetw is part of the contoso1 and contoso2 GitHub organizations, but they all have not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify those organizations.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console",
 }
@@ -258,7 +258,7 @@ exports[`Multiple entities, all unverified 2`] = `
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso1 and contoso2 GitHub organizations, but they all have not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
+  "longDescription": "@johndoetw is part of the contoso1 and contoso2 GitHub organizations, but they all have not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify those organizations.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console&pull=120",
 }
@@ -401,7 +401,7 @@ exports[`Via entity, participating in all workstreams, unverified 1`] = `
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
+  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this organization.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console",
 }
@@ -412,7 +412,7 @@ exports[`Via entity, participating in all workstreams, unverified 2`] = `
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
+  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this organization.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console&pull=120",
 }
@@ -445,7 +445,7 @@ exports[`Via entity, participating in other workstreams but not that one, unveri
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
+  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this organization.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console",
 }
@@ -456,7 +456,7 @@ exports[`Via entity, participating in other workstreams but not that one, unveri
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
+  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this organization.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console&pull=120",
 }
@@ -489,7 +489,7 @@ exports[`Via entity, participating in that particular workstream, unverified 1`]
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
+  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this organization.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console",
 }
@@ -500,7 +500,7 @@ exports[`Via entity, participating in that particular workstream, unverified 2`]
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
+  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this organization.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console&pull=120",
 }

--- a/__tests__/__snapshots__/get-user-status.js.snap
+++ b/__tests__/__snapshots__/get-user-status.js.snap
@@ -49,7 +49,7 @@ exports[`Individual, participating in all workstreams, unverified 1`] = `
   "context": "Participation",
   "description": "@johndoetw is not yet verified",
   "isNothing": false,
-  "longDescription": "@johndoetw has signed up to participate as an individual, but has not yet been verified. Hold tight while we sort this out on our end!",
+  "longDescription": "@johndoetw has signed up to participate as an individual, but has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this individual.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console",
 }
@@ -60,7 +60,7 @@ exports[`Individual, participating in all workstreams, unverified 2`] = `
   "context": "Participation",
   "description": "@johndoetw is not yet verified",
   "isNothing": false,
-  "longDescription": "@johndoetw has signed up to participate as an individual, but has not yet been verified. Hold tight while we sort this out on our end!",
+  "longDescription": "@johndoetw has signed up to participate as an individual, but has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this individual.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console&pull=120",
 }
@@ -93,7 +93,7 @@ exports[`Individual, participating in other workstreams but not that one, unveri
   "context": "Participation",
   "description": "@johndoetw is not yet verified",
   "isNothing": false,
-  "longDescription": "@johndoetw has signed up to participate as an individual, but has not yet been verified. Hold tight while we sort this out on our end!",
+  "longDescription": "@johndoetw has signed up to participate as an individual, but has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this individual.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console",
 }
@@ -104,7 +104,7 @@ exports[`Individual, participating in other workstreams but not that one, unveri
   "context": "Participation",
   "description": "@johndoetw is not yet verified",
   "isNothing": false,
-  "longDescription": "@johndoetw has signed up to participate as an individual, but has not yet been verified. Hold tight while we sort this out on our end!",
+  "longDescription": "@johndoetw has signed up to participate as an individual, but has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this individual.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console&pull=120",
 }
@@ -137,7 +137,7 @@ exports[`Individual, participating in that particular workstream, unverified 1`]
   "context": "Participation",
   "description": "@johndoetw is not yet verified",
   "isNothing": false,
-  "longDescription": "@johndoetw has signed up to participate as an individual, but has not yet been verified. Hold tight while we sort this out on our end!",
+  "longDescription": "@johndoetw has signed up to participate as an individual, but has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this individual.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console",
 }
@@ -148,7 +148,7 @@ exports[`Individual, participating in that particular workstream, unverified 2`]
   "context": "Participation",
   "description": "@johndoetw is not yet verified",
   "isNothing": false,
-  "longDescription": "@johndoetw has signed up to participate as an individual, but has not yet been verified. Hold tight while we sort this out on our end!",
+  "longDescription": "@johndoetw has signed up to participate as an individual, but has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this individual.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console&pull=120",
 }
@@ -247,7 +247,7 @@ exports[`Multiple entities, all unverified 1`] = `
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso1 and contoso2 GitHub organizations, but they all have not yet been verified. Hold tight while we sort this out on our end!",
+  "longDescription": "@johndoetw is part of the contoso1 and contoso2 GitHub organizations, but they all have not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console",
 }
@@ -258,7 +258,7 @@ exports[`Multiple entities, all unverified 2`] = `
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso1 and contoso2 GitHub organizations, but they all have not yet been verified. Hold tight while we sort this out on our end!",
+  "longDescription": "@johndoetw is part of the contoso1 and contoso2 GitHub organizations, but they all have not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console&pull=120",
 }
@@ -401,7 +401,7 @@ exports[`Via entity, participating in all workstreams, unverified 1`] = `
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end!",
+  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console",
 }
@@ -412,7 +412,7 @@ exports[`Via entity, participating in all workstreams, unverified 2`] = `
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end!",
+  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console&pull=120",
 }
@@ -445,7 +445,7 @@ exports[`Via entity, participating in other workstreams but not that one, unveri
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end!",
+  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console",
 }
@@ -456,7 +456,7 @@ exports[`Via entity, participating in other workstreams but not that one, unveri
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end!",
+  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console&pull=120",
 }
@@ -489,7 +489,7 @@ exports[`Via entity, participating in that particular workstream, unverified 1`]
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end!",
+  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console",
 }
@@ -500,7 +500,7 @@ exports[`Via entity, participating in that particular workstream, unverified 2`]
   "context": "Participation",
   "description": "@johndoetw participates on behalf of an unverified entity",
   "isNothing": false,
-  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end!",
+  "longDescription": "@johndoetw is part of the contoso GitHub organization, but it has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="https://github.com/whatwg/participate.whatwg.org#process-for-editors">these instructions</a> to verify this entity.",
   "state": "pending",
   "target_url": "https://participate.whatwg.org/agreement-status?user=johndoetw&repo=console&pull=120",
 }

--- a/config.json
+++ b/config.json
@@ -7,5 +7,6 @@
   "serverURL": "https://participate.whatwg.org/",
   "statusPath": "/agreement-status",
   "steeringGroupEmail": "sg@whatwg.org",
-  "specOrg": "whatwg"
+  "specOrg": "whatwg",
+  "verifyInstructionsURL": "https://github.com/whatwg/participate.whatwg.org#process-for-editors"
 }

--- a/lib/get-user-status.js
+++ b/lib/get-user-status.js
@@ -110,7 +110,7 @@ function statusIndividualUnverified(submitterGitHubID, targetURL) {
     context: "Participation",
 
     isNothing: false,
-    longDescription: html`@${submitterGitHubID} has signed up to participate as an individual, but has not yet been verified. Hold tight while we sort this out on our end!`
+    longDescription: html`@${submitterGitHubID} has signed up to participate as an individual, but has not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="${config.verifyInstructionsURL}">these instructions</a> to verify this individual.`
   };
 }
 
@@ -138,7 +138,7 @@ function statusEntitiesUnverified(submitterGitHubID, targetURL, entities) {
     context: "Participation",
 
     isNothing: false,
-    longDescription: html`@${submitterGitHubID} is part of the ${orgs} GitHub ${word}, but ${pronoun} ${haveVerb} not yet been verified. Hold tight while we sort this out on our end!`
+    longDescription: html`@${submitterGitHubID} is part of the ${orgs} GitHub ${word}, but ${pronoun} ${haveVerb} not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="${config.verifyInstructionsURL}">these instructions</a> to verify this entity.`
   };
 }
 

--- a/lib/get-user-status.js
+++ b/lib/get-user-status.js
@@ -129,7 +129,7 @@ function statusEntity(submitterGitHubID, repoName, targetURL, entity) {
 }
 
 function statusEntitiesUnverified(submitterGitHubID, targetURL, entities) {
-  const { orgs, word, pronoun, haveVerb } = entityVerbiage(entities);
+  const { orgs, word, pronoun, pronoun2, haveVerb } = entityVerbiage(entities);
 
   return {
     state: "pending",
@@ -138,7 +138,7 @@ function statusEntitiesUnverified(submitterGitHubID, targetURL, entities) {
     context: "Participation",
 
     isNothing: false,
-    longDescription: html`@${submitterGitHubID} is part of the ${orgs} GitHub ${word}, but ${pronoun} ${haveVerb} not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="${config.verifyInstructionsURL}">these instructions</a> to verify this entity.`
+    longDescription: html`@${submitterGitHubID} is part of the ${orgs} GitHub ${word}, but ${pronoun} ${haveVerb} not yet been verified. Hold tight while we sort this out on our end! If you are a spec editor, follow <a href="${config.verifyInstructionsURL}">these instructions</a> to verify ${pronoun2} ${word}.`
   };
 }
 


### PR DESCRIPTION
It was not clear to me, as a WHATWG spec editor, that verifying a participant was a step I needed to do. Providing a link here, on the page which is linked to from the IPR bot failure, makes it clear that spec editors are empowered and expected to verify individuals and entities, and links to the existing good instructions on how to do so.