### PR TITLE
Manually update to node:20.16.0-bookworm-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.15.0-bookworm-slim
+FROM node:20.16.0-bookworm-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
See https://github.com/dependabot/dependabot-core/issues/2247 for why this is necessary.

Closes #409.